### PR TITLE
Add possibility to set collpasible status in the widget configuration

### DIFF
--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -72,7 +72,7 @@ angular.module('adf')
           // collapse exposed $scope.widgetState property
           if (!$scope.widgetState) {
             $scope.widgetState = {};
-            $scope.widgetState.isCollapsed = false;
+            $scope.widgetState.isCollapsed= (w.collapsed === true) ? w.collapsed : false;
           }
 
         } else {


### PR DESCRIPTION
Adding this I can define the widget initial status of collapsible in this way:

```javascript
dashboardProvider
                .widget('myWidget', {
                    title: 'My Widget',
                    description: 'My Widget open collapsed',
                    templateUrl: '{widgetsPath}/myWidget.html',
                    controller: 'myWidgetCtrl',
                    reload: true,
                    collapsed: true
                });
```