### PR TITLE
Adding styleClass to widget definition to bind custom css styles

### DIFF
--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -68,6 +68,7 @@ angular.module('adf.provider', [])
     *   - `controllerAs` - `{string=}` - A controller alias name. If present the controller will be
     *      published to scope under the `controllerAs` name.
     *   - `frameless` - `{boolean=}` - false if the widget should be shown in frameless mode. The default is false.
+    *   - `styleClass` - `{object}` - space delimited string or map of classes bound to the widget.
     *   - `template` - `{string=|function()=}` - html template as a string.
     *   - `templateUrl` - `{string=}` - path to an html template.
     *   - `reload` - `{boolean=}` - true if the widget could be reloaded. The default is false.

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -48,6 +48,10 @@ angular.module('adf')
             definition.frameless = w.frameless;
           }
 
+          if (!definition.styleClass) {
+            definition.styleClass = w.styleClass;
+          }
+
           // set id for sortable
           if (!definition.wid) {
             definition.wid = dashboard.id();

--- a/src/templates/widget.html
+++ b/src/templates/widget.html
@@ -1,4 +1,4 @@
-<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="{'panel panel-default':!widget.frameless || editMode}" class="widget">
+<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="[{'panel panel-default':!widget.frameless || editMode},definition.styleClass]" class="widget">
   <div class="panel-heading clearfix" ng-if="!widget.frameless || editMode">
     <div ng-include src="definition.titleTemplateUrl"></div>
   </div>


### PR DESCRIPTION
This change adds `styleClass` support for binding custom styles to individual widgets, similar to the `styleClass` attribute already supported by row and column objects.  For example, you could add `panel-warning` to a widget to apply the Bootstrap warning style to the widget frame.