### PR TITLE
Revert "Adding styleClass to widget definition to bind custom css styles"

### DIFF
--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -69,7 +69,6 @@ angular.module('adf.provider', [])
     *   - `controllerAs` - `{string=}` - A controller alias name. If present the controller will be
     *      published to scope under the `controllerAs` name.
     *   - `frameless` - `{boolean=}` - false if the widget should be shown in frameless mode. The default is false.
-    *   - `styleClass` - `{object}` - space delimited string or map of classes bound to the widget.
     *   - `template` - `{string=|function()=}` - html template as a string.
     *   - `templateUrl` - `{string=}` - path to an html template.
     *   - `reload` - `{boolean=}` - true if the widget could be reloaded. The default is false.

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -48,10 +48,6 @@ angular.module('adf')
             definition.frameless = w.frameless;
           }
 
-          if (!definition.styleClass) {
-            definition.styleClass = w.styleClass;
-          }
-
           // set id for sortable
           if (!definition.wid) {
             definition.wid = dashboard.id();

--- a/src/templates/widget.html
+++ b/src/templates/widget.html
@@ -1,4 +1,4 @@
-<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="[{'panel panel-default':!widget.frameless || editMode},definition.styleClass]" class="widget">
+<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="{'panel panel-default':!widget.frameless || editMode}" class="widget">
   <div class="panel-heading clearfix" ng-if="!widget.frameless || editMode">
     <div ng-include src="definition.titleTemplateUrl"></div>
   </div>


### PR DESCRIPTION
Reverts angular-dashboard-framework/angular-dashboard-framework#171

As discussed in Issue #187 **ng-class in widget.html not compatible with Angular 1.2 and 1.3**, changing the ng-class attribute on widget broke compatibility with Angular 1.2.x and 1.3.x.  I recommend reverting this for now, we can add it back in the future when compatibility is no longer a concern.