### PR TITLE
Add support for publishing to npm and consuming as commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-dashboard-framework');
+module.exports = 'adf';

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "gulp-replace": "^0.5.4",
     "gulp-rev": "^6.0.1",
     "gulp-rev-replace": "^0.4.2",
+    "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.4.1",
     "gulp-usemin": "^0.3.14",
     "gulp-useref": "^1.3.0",
-    "gulp-sass": "^2.0.4",
     "jshint-stylish": "^2.0.1",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.2.0",
@@ -39,6 +39,13 @@
     "karma-firefox-launcher": "~0.1",
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.3.7",
-    "karma-phantomjs-launcher": "^0.2.1"
+    "karma-phantomjs-launcher": "^0.2.1",
+    "phantomjs": "~2.1.3"
+  },
+  "peerDependencies": {
+    "angular": ">=1.2",
+    "angular-ui-bootstrap": ">=0.14.3",
+    "bootstrap": "^3.3.6",
+    "sortablejs": "^1.4.2"
   }
 }


### PR DESCRIPTION
After every release you'll just need to run `npm publish` after bumping the version in package.json

If you have any questions just let me know, thanks! :smile: 

Closes #160