### PR TITLE
Added support for custom widget template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ gulp all
 ```
 The sample and the final build of angular-dashboard-framework are now in the dist directory.
 
+## Custom widget wrapper template
+You can now use your own template instead of the default bootstrap panel layout. Override the default template by specifying your custom template path via the dashboardProvider in the config phase.
+
+```javascript
+angular
+    .module('adfWidgetSample', ['adf', 'LocalStorageModule'])
+    .config(function(dashboardProvider, localStorageServiceProvider){
+       localStorageServiceProvider.setPrefix('adf.my-custom-chart');
+       dashboardProvider.customWidgetTemplate = 'src/custom-tmpl/view.html'
+    }
+```
+
+
 ## Contributing
 
 Please do not commit changes to the dist folder. The dist folder is only generated for releases.

--- a/README.md
+++ b/README.md
@@ -59,19 +59,6 @@ gulp all
 ```
 The sample and the final build of angular-dashboard-framework are now in the dist directory.
 
-## Custom widget wrapper template
-You can now use your own template instead of the default bootstrap panel layout. Override the default template by specifying your custom template path via the dashboardProvider in the config phase.
-
-```javascript
-angular
-    .module('adfWidgetSample', ['adf', 'LocalStorageModule'])
-    .config(function(dashboardProvider, localStorageServiceProvider){
-       localStorageServiceProvider.setPrefix('adf.my-custom-chart');
-       dashboardProvider.customWidgetTemplate = 'src/custom-tmpl/view.html'
-    }
-```
-
-
 ## Contributing
 
 Please do not commit changes to the dist folder. The dist folder is only generated for releases.

--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -44,6 +44,7 @@ angular.module('adf.provider', [])
           <span class="sr-only">loading ...</span>\n\
         </div>\n\
       </div>';
+    var customWidgetTemplatePath = null;
 
     // default apply function of widget.edit.apply
     var defaultApplyFunction = function(){
@@ -210,17 +211,21 @@ angular.module('adf.provider', [])
     };
 
     /**
-     * @ngdoc property
-     * @name adf.dashboardProvider#widgetCustomTemplatePath
+     * @ngdoc method
+     * @name adf.dashboardProvider#customWidgetTemplatePath
      * @propertyOf adf.dashboardProvider
      * @description
      *
      * Changes the container template for the widgets
      *
-     * @param {string} template loading template
+     * @param {string} path to the custom widget template
      *
+     * @returns {Object} self
      */
-    this.widgetCustomTemplateUrl = null;
+    this.customWidgetTemplatePath = function(templatePath) {
+      customWidgetTemplatePath = templatePath;
+      return this;
+    };
 
    /**
     * @ngdoc service
@@ -246,7 +251,7 @@ angular.module('adf.provider', [])
         structures: structures,
         messageTemplate: messageTemplate,
         loadingTemplate: loadingTemplate,
-        widgetCustomTemplateUrl: this.widgetCustomTemplateUrl,
+        customWidgetTemplatePath: customWidgetTemplatePath,
 
         /**
          * @ngdoc method

--- a/src/scripts/provider.js
+++ b/src/scripts/provider.js
@@ -209,6 +209,19 @@ angular.module('adf.provider', [])
       return this;
     };
 
+    /**
+     * @ngdoc property
+     * @name adf.dashboardProvider#widgetCustomTemplatePath
+     * @propertyOf adf.dashboardProvider
+     * @description
+     *
+     * Changes the container template for the widgets
+     *
+     * @param {string} template loading template
+     *
+     */
+    this.widgetCustomTemplateUrl = null;
+
    /**
     * @ngdoc service
     * @name adf.dashboard
@@ -233,6 +246,7 @@ angular.module('adf.provider', [])
         structures: structures,
         messageTemplate: messageTemplate,
         loadingTemplate: loadingTemplate,
+        widgetCustomTemplateUrl: this.widgetCustomTemplateUrl,
 
         /**
          * @ngdoc method

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -27,6 +27,15 @@
 angular.module('adf')
   .directive('adfWidget', function($injector, $q, $log, $uibModal, $rootScope, dashboard, adfTemplatePath) {
 
+    function getWidgetTemplateUrl() {
+        var templateUrl = adfTemplatePath + 'widget.html';
+        if (dashboard.widgetCustomTemplateUrl) {
+            templateUrl = dashboard.widgetCustomTemplateUrl;
+        }
+
+        return templateUrl;
+    }
+
     function preLink($scope) {
       var definition = $scope.definition;
       if (definition) {
@@ -238,7 +247,7 @@ angular.module('adf')
       replace: true,
       restrict: 'EA',
       transclude: false,
-      templateUrl: adfTemplatePath + 'widget.html',
+      templateUrl: getWidgetTemplateUrl(),
       scope: {
         definition: '=',
         col: '=column',

--- a/src/scripts/widget.js
+++ b/src/scripts/widget.js
@@ -27,15 +27,6 @@
 angular.module('adf')
   .directive('adfWidget', function($injector, $q, $log, $uibModal, $rootScope, dashboard, adfTemplatePath) {
 
-    function getWidgetTemplateUrl() {
-        var templateUrl = adfTemplatePath + 'widget.html';
-        if (dashboard.widgetCustomTemplateUrl) {
-            templateUrl = dashboard.widgetCustomTemplateUrl;
-        }
-
-        return templateUrl;
-    }
-
     function preLink($scope) {
       var definition = $scope.definition;
       if (definition) {
@@ -247,7 +238,7 @@ angular.module('adf')
       replace: true,
       restrict: 'EA',
       transclude: false,
-      templateUrl: getWidgetTemplateUrl(),
+      templateUrl: dashboard.customWidgetTemplatePath ? dashboard.customWidgetTemplatePath : adfTemplatePath + 'widget.html',
       scope: {
         definition: '=',
         col: '=column',

--- a/test/unit/providerSpec.js
+++ b/test/unit/providerSpec.js
@@ -105,4 +105,11 @@ describe('Dashboard Provider tests', function() {
     expect(dashboard.idEquals(1, 1)).toBe(true);
   }));
 
+  it('should set custom widget template url', function() {
+    var widgetCustomTemplateUrl = '/app/templates/customWidget.html';
+    provider.widgetCustomTemplateUrl = widgetCustomTemplateUrl
+    var dashboard = provider.$get();
+    expect(dashboard.widgetCustomTemplateUrl).toBe(widgetCustomTemplateUrl);
+  });
+
 });

--- a/test/unit/providerSpec.js
+++ b/test/unit/providerSpec.js
@@ -106,10 +106,10 @@ describe('Dashboard Provider tests', function() {
   }));
 
   it('should set custom widget template url', function() {
-    var widgetCustomTemplateUrl = '/app/templates/customWidget.html';
-    provider.widgetCustomTemplateUrl = widgetCustomTemplateUrl
+    var customWidgetTemplatePath = '/app/templates/customWidget.html';
+    provider.customWidgetTemplatePath(customWidgetTemplatePath);
     var dashboard = provider.$get();
-    expect(dashboard.widgetCustomTemplateUrl).toBe(widgetCustomTemplateUrl);
+    expect(dashboard.customWidgetTemplatePath).toBe(customWidgetTemplatePath);
   });
 
 });

--- a/test/unit/widgetSpec.js
+++ b/test/unit/widgetSpec.js
@@ -138,9 +138,10 @@ describe('widget directive tests', function() {
     };
 
     spyOn($templateCache, 'get').and.returnValue('<div></div>');
-    dashboard.widgetCustomTemplateUrl = '..src/templates/customWidget.html';
+    var customWidgetTemplatePath = null;
+    dashboard.customWidgetTemplatePath = '..src/templates/customWidget.html';
     var element = compileTemplate(directive);
-    expect($templateCache.get).toHaveBeenCalledWith(dashboard.widgetCustomTemplateUrl);
+    expect($templateCache.get).toHaveBeenCalledWith(dashboard.customWidgetTemplatePath);
   });
 
   describe('delete functions', function(){

--- a/test/unit/widgetSpec.js
+++ b/test/unit/widgetSpec.js
@@ -32,7 +32,8 @@ describe('widget directive tests', function() {
       $uibModalInstance,
       $scope,
       directive,
-      dashboard;
+      dashboard,
+      $templateCache;
 
   // Load the myApp module, which contains the directive
   beforeEach(function(){
@@ -59,13 +60,14 @@ describe('widget directive tests', function() {
 
   // Store references to $rootScope and $compile
   // so they are available to all tests in this describe block
-  beforeEach(inject(function(_$compile_, _$rootScope_, _$uibModal_, _dashboard_){
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$uibModal_, _dashboard_, _$templateCache_){
       // The injector unwraps the underscores (_) from around the parameter names when matching
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       $uibModal = _$uibModal_;
       dashboard = _dashboard_;
       dashboard.widgets = [];
+      $templateCache = _$templateCache_;
 
       $scope = $rootScope.$new();
       directive = '<adf-widget definition="definition" column="column" options="options" edit-mode="editMode" widget-state="widgetState" />';
@@ -112,6 +114,33 @@ describe('widget directive tests', function() {
     expect(counter).toBe(1);
     element.find('.glyphicon-refresh').click();
     expect(counter).toBe(2);
+  });
+
+  it('should load the default widget template', function(){
+    dashboard.widgets['test'] = {
+      template: '<div class="hello">Hello World</div>',
+    };
+    $scope.definition = {
+      type: 'test'
+    };
+
+    spyOn($templateCache, 'get').and.returnValue('<div></div>');
+    var element = compileTemplate(directive);
+    expect($templateCache.get).toHaveBeenCalledWith('../src/templates/widget.html');
+  });
+
+  it('should load a custom widget template', function(){
+    dashboard.widgets['test'] = {
+      template: '<div class="hello">Hello World</div>',
+    };
+    $scope.definition = {
+      type: 'test'
+    };
+
+    spyOn($templateCache, 'get').and.returnValue('<div></div>');
+    dashboard.widgetCustomTemplateUrl = '..src/templates/customWidget.html';
+    var element = compileTemplate(directive);
+    expect($templateCache.get).toHaveBeenCalledWith(dashboard.widgetCustomTemplateUrl);
   });
 
   describe('delete functions', function(){


### PR DESCRIPTION
You can now use your own wrapper template instead of the default bootstrap panel layout. Override the default template by specifying your custom template path via the dashboardProvider in the config phase.

```javascript
angular
    .module('adfWidgetSample', ['adf', 'LocalStorageModule'])
    .config(function(dashboardProvider, localStorageServiceProvider){
       localStorageServiceProvider.setPrefix('adf.my-custom-chart');
       dashboardProvider.customWidgetTemplate = 'src/custom-tmpl/view.html'
    }
```

The requirement for this to work is that your custom template is using the ng-click/ng-if attributes as in the default template. This gives users a way to design their unique look of angular-dashboard-framework.

An working example in production code.
![custom-tmpl-edit](https://cloud.githubusercontent.com/assets/7448249/15530202/4a29e044-2253-11e6-9cee-f55d56081d4a.PNG)
![custom-tmpl-view](https://cloud.githubusercontent.com/assets/7448249/15530206/4ce40792-2253-11e6-9aee-0ed66a979354.PNG)

...and is using the following template:

```html
<div adf-id="{{definition.wid}}" adf-widget-type="{{definition.type}}" ng-class="widgetClasses(widget, definition)" class="porlet block-flat">
    <div class="header">
        <div class="actions">
            <a class="minimize" href="#" title="collapse widget" ng-show="options.collapsible && !widgetState.isCollapsed" ng-click="widgetState.isCollapsed = !widgetState.isCollapsed">
                <i class="fa fa-chevron-up"></i>
            </a>
            <a class="maximize" href="#" title="collapse widget" ng-show="options.collapsible && widgetState.isCollapsed" ng-click="widgetState.isCollapsed = !widgetState.isCollapsed">
                <i class="fa fa-chevron-down"></i>
            </a>
            <a class="refresh" href="#" title="ladda om widget" ng-if="widget.reload" ng-click="reload()">
                <i class="fa fa-repeat"></i>
            </a>
            <a href="#" title="byt plats p� widget" class="adf-move" ng-if="editMode">
              <i class="fa fa-arrows" aria-hidden="true"></i>
            </a>
            <a href="#" title="edit widget configuration" ng-click="edit()" ng-if="editMode">
              <i class="fa fa-cog" aria-hidden="true"></i>
            </a>

            <a class="toggle-fullscreen" href="#" ng-click="openFullScreen()" ng-show="options.maximizable">
                <i class="fa fa-arrows-alt"></i>
            </a>

            <a class="close-down" href="#" title="ta bort widget" ng-click="remove()" ng-if="editMode"><i class="fa fa-times"></i></a>
         </div>
		<h3>{{definition.title}}</h3>
	</div>
	<div class="content" uib-collapse="widgetState.isCollapsed">
        <adf-widget-content model="definition" content="widget" />
	</div>
</div>
````

Good idea? Comments?

Thx for a good framework!!
