### PR TITLE
BUG-fix: enableConfirmDelete is now configurable via attribute

### DIFF
--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -464,7 +464,7 @@ angular.module('adf')
         var options = {
           name: $attr.name,
           editable: true,
-          enableConfirmDelete: stringToBoolean($attr.enableconfirmdelete),
+          enableConfirmDelete: stringToBoolean($attr.enableConfirmDelete),
           maximizable: stringToBoolean($attr.maximizable),
           collapsible: stringToBoolean($attr.collapsible),
           categories: stringToBoolean($attr.categories)


### PR DESCRIPTION
The bug is that the value of enableConfirmDelete always becomes false
beacuse it binds to a attribute that is lowercased. In the documenation it
clearly states that the attribute should be written like
enable-confirm-delete. Wich means that is has to be camelcased in the
directive.

```javascript
<adf-dashboard
       name="{string}"
       [editable="{boolean}"]
       [collapsible="{boolean}"]
       [maximizable="{boolean}"]
       [enable-confirm-delete="{boolean}"]
       [structure="{string}"]
       [adf-model="{object}"]
       [adf-widget-filter="{function}"]
       [continuous-edit-mode="{boolean}"]>
</adf-dashboard>
```