### PR TITLE
bugfix: use of categories no longer breaks add widget

### DIFF
--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -253,17 +253,17 @@ angular.module('adf')
      */
     function createCategories(widgets){
       var categories = {};
-      angular.forEach(widgets, function(widget){
+      angular.forEach(widgets, function(widget, key){
         var category = widget.category;
         // if the widget has no category use a default one
         if (!category){
           category = 'Miscellaneous';
         }
         // push widget to category array
-        if (!categories[category]){
-          categories[category] = [];
+        if (angular.isUndefined(categories[category])){
+          categories[category] = {widgets: {}};
         }
-        categories[category].push(widget);
+        categories[category].widgets[key] = widget;
       });
       return categories;
     }

--- a/src/templates/widget-add.html
+++ b/src/templates/widget-add.html
@@ -8,8 +8,8 @@
     <uib-accordion ng-init="categorized = createCategories(widgets)">
       <uib-accordion-group heading="{{category.name}}" ng-repeat="category in categorized | adfOrderByObjectKey: 'name'">
         <dl class="dl-horizontal">
-          <dt ng-repeat-start="widget in category | adfOrderByObjectKey: 'key'">
-            <a href="" ng-click="addWidget(key)">
+          <dt ng-repeat-start="widget in category.widgets | adfOrderByObjectKey: 'key'">
+            <a href="" ng-click="addWidget(widget.key)">
               {{widget.title}}
             </a>
           </dt>

--- a/test/unit/dashboardSpec.js
+++ b/test/unit/dashboardSpec.js
@@ -340,9 +340,9 @@ describe('Dashboard Directive tests', function () {
 
         // create categories and test
         var categories = scope.createCategories(widgets);
-        expect(categories.a.length).toBe(2);
-        expect(categories.b.length).toBe(1);
-        expect(categories.Miscellaneous.length).toBe(1);
+        expect(Object.keys(categories.a.widgets).length).toBe(2);
+        expect(Object.keys(categories.b.widgets).length).toBe(1);
+        expect(Object.keys(categories.Miscellaneous.widgets).length).toBe(1);
       });
 
       it('should close add widget dialog', function(){


### PR DESCRIPTION
Closes angular-dashboard-framework/angular-dashboard-framework#257 .

Fix for regression from angular-dashboard-framework/angular-dashboard-framework@816ab406f3ba7b9a866f7a1bd36f64dfb5786b55
which broke `categories` feature.