### PR TITLE
empty name in 'adfDashboardChanged' listener

### DIFF
--- a/src/scripts/dashboard.js
+++ b/src/scripts/dashboard.js
@@ -350,7 +350,7 @@ angular.module('adf')
           }
 
           if (!$scope.editMode){
-            $rootScope.$broadcast('adfDashboardChanged', name, model);
+            $rootScope.$broadcast('adfDashboardChanged', $scope.name, model);
           }
         };
 


### PR DESCRIPTION
There is an issue with empty name in 'adfDashboardChanged' listener. I belive it is caused by late adf-dashboard name attribute assignment. We can fix this by broadcasting $scope.name value instead name(becouse it inited at start only).