### PR TITLE
pass definition down to widget controller

### DIFF
--- a/src/scripts/directives/adf-widget-content.directive.js
+++ b/src/scripts/directives/adf-widget-content.directive.js
@@ -67,7 +67,8 @@ angular.module('adf')
       var base = {
         $scope: templateScope,
         widget: model,
-        config: model.config
+        config: model.config,
+        definition: $scope.$parent.definition
       };
 
       // get resolve promises from content object


### PR DESCRIPTION
I needed to be able to change the title depending of data pulled in the widget controller, by passing the defenition down to the widget controller I am now able to add curly brackets in the title and pass data to the definition and this way update the title with conditional data, without changing the config.title

example usage:
config.title = "this a test: {{definition.test}}"

and in the widget controller i also inject definition and set
definition.test = "hello world!";

kind regards
c_bb
