### PR TITLE
ref(#294) readColumns() return wrong column size when a column has rows

### DIFF
--- a/src/scripts/directives/adf-dashboard.directive.js
+++ b/src/scripts/directives/adf-dashboard.directive.js
@@ -115,7 +115,9 @@ angular.module('adf')
       if (angular.isDefined(root.rows)) {
         angular.forEach(root.rows, function (row) {
           angular.forEach(row.columns, function (col) {
-            columns.push(col);
+            if (!col.hasOwnProperty('rows')) {
+              columns.push(col);
+            }
             // keep reading columns until we can't any more
             readColumns(col, columns);
           });
@@ -329,6 +331,9 @@ angular.module('adf')
         // edit mode
         $scope.editMode = false;
         $scope.editClass = '';
+
+        // expose readColumns function in $scope in order to test the interface
+        $scope.readColumns = readColumns;
 
         //passs translate function from dashboard so we can translate labels inside html templates
         $scope.translate = dashboard.translate;

--- a/test/unit/directives/adf-dashboard.directive.spec.js
+++ b/test/unit/directives/adf-dashboard.directive.spec.js
@@ -424,6 +424,28 @@ describe('Dashboard Directive tests', function () {
               }]
           }]
         };
+
+        dashboard.structures['3-9 (12/6-6)'] = {
+          rows: [{
+            columns: [{
+              styleClass: 'col-md-3'
+            }, {
+              styleClass: 'col-md-9',
+              rows: [{
+                columns: [{
+                  styleClass: 'col-md-12'
+                }]
+              }, {
+                columns: [{
+                  styleClass: 'col-md-6'
+                }, {
+                  styleClass: 'col-md-6'
+                }]
+              }]
+            }]
+          }]
+        };
+
       });
 
       it('should change the dashboard structure', function(){
@@ -437,6 +459,16 @@ describe('Dashboard Directive tests', function () {
 
         // model shoule have two column in 12 structure
         expect($scope.model.rows[0].columns.length).toBe(1);
+      });
+
+      it('should read the correct number of columns in a structure', function(){
+        var element = compileTemplate(directive);
+        var isolatedScope = element.isolateScope();
+
+        isolatedScope.editDashboardDialog();
+        $uibModal.opts.scope.changeStructure('3-9 (12/6-6)', dashboard.structures['3-9 (12/6-6)']);
+
+        expect(isolatedScope.readColumns($scope.model).length).toBe(4);
       });
 
       it('should change the dashboard structure and move widgets', function(){


### PR DESCRIPTION
Details:
- Fixed the readColumns function by filtering out columns with structuring purpose
- Expose readColumns in the scope in order to be testable
- New test case